### PR TITLE
Add security and code of conduct notices

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# CODE OF CONDUCT
+
+The projects hosted in the JupyterLab organizations follow the
+[Project Jupyter Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+Security Policy
+
+## Reporting a Vulnerability
+
+If you find a security vulnerability in Jupyter, please report it to security@ipython.org.
+
+See more information in our [docs](https://jupyter-server.readthedocs.io/en/stable/operators/security.html).


### PR DESCRIPTION
Add security and code of conduct - the same ones as in the JupyterLab organization.