### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # CODE OF CONDUCT
 
-The projects hosted in the JupyterLab organizations follow the
+The projects hosted in the Jupyter organization follow the
 [Project Jupyter Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md).


### PR DESCRIPTION
The code of conduct was mentioning the JupyterLab organization before:

![image](https://github.com/jupyter/.github/assets/591645/14dfd4bc-6197-4a23-882d-36447559c5ce)
